### PR TITLE
stat::st_size reports wrong size

### DIFF
--- a/sdk/include/sys/types.h
+++ b/sdk/include/sys/types.h
@@ -13,7 +13,7 @@
 typedef int dev_t;
 typedef int mode_t;
 typedef int ino_t;
-typedef int uid_t;
-typedef int gid_t;
+typedef unsigned short uid_t;
+typedef unsigned short gid_t;
 typedef int off_t;
 typedef unsigned short nlink_t;


### PR DESCRIPTION
If I perform stat() on a file, the st_size field contains the wrong filesize. I tested against FeOS-built and devkitARM-built:

struct stat buf;
printf("stat: %d\n", stat("/data/anagram/dict.z", &buf));
printf("size: %d\n", buf.st_size);
fopen("/data/anagram/dict.z", "r");
fseek(fp, 0, SEEK_END);
printf("size: %d\n", ftell(fp));

Output with FeOS app:
stat: 0
size: 65477632
size: 91148

Output with devkitARM app:
stat: 0
size: 91148
size: 91148
